### PR TITLE
fix: 修复搜素框取消事件触发

### DIFF
--- a/src/search/index.tsx
+++ b/src/search/index.tsx
@@ -10,7 +10,7 @@ import { CreateElement, RenderContext } from 'vue/types';
 import { DefaultSlots, ScopedSlot } from '../utils/types';
 import VanEmptyCol from '../emptycol';
 
-const [createComponent, bem, t] = createNamespace('search');
+const [createComponent, bem] = createNamespace('search');
 
 export type SearchProps = {
   shape: 'sqaure' | 'round';
@@ -65,7 +65,7 @@ function Search(
     }
 
     function onCancel() {
-      if (slots.action) {
+      if (slots.action && slots.action()) {
         return;
       }
       // 平台这里 定义为按钮 不是清空操作
@@ -76,9 +76,27 @@ function Search(
     }
 
     return (
-      <div class={bem('action')} role="button" tabindex="0" onClick={onCancel} vusion-slot-name="action">
-        {!designer ? ((slots.action && slots.action()) ? slots.action() : props.actiontext) : null}
-        {designer ? ((slots.action && !slots.action() && !props.actiontext) ? <VanEmptyCol></VanEmptyCol> : ((slots.action && slots.action()) ? slots.action() : props.actiontext)) : null}
+      <div
+        class={bem('action')}
+        role="button"
+        tabindex="0"
+        onClick={onCancel}
+        vusion-slot-name="action"
+      >
+        {!designer
+          ? slots.action && slots.action()
+            ? slots.action()
+            : props.actiontext
+          : null}
+        {designer ? (
+          slots.action && !slots.action() && !props.actiontext ? (
+            <VanEmptyCol></VanEmptyCol>
+          ) : slots.action && slots.action() ? (
+            slots.action()
+          ) : (
+            props.actiontext
+          )
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/23186129/231363440-88005728-c5a4-4b31-bfdb-06724050eda4.png">

由于增加vusion-slot-name=“action“， slots.action一直存在了，导致了onCancel逻辑异常
